### PR TITLE
Feature | ER-27 Add reusable permission check helper with wildcard support

### DIFF
--- a/src/app/api/auth/permissions.ts
+++ b/src/app/api/auth/permissions.ts
@@ -1,0 +1,43 @@
+/**
+ * Permission Structure Overview:
+ * Permissions are defined using a three-part syntax: [RESOURCE]:[ACTION]:[SCOPE].
+ * This structure provides a granular and consistent way to manage access control across the application.
+ *
+ * Components:
+ * - RESOURCE: The entity being acted upon (e.g., 'USER', 'RATING', 'ORGANIZATION').
+ * - ACTION: The operation allowed (e.g., 'READ', 'CREATE', 'UPDATE', 'DELETE', or '*' for all actions).
+ * - SCOPE: The extent of access:
+ *   - 'OWN': Applies to the user's own data (e.g., their own profile or ratings).
+ *   - 'ASSIGNED': Applies to data of entities assigned to the user (e.g., employees under a supervisor, or organizations via OrganizationMember).
+ *   - '*': Applies to all data of that resource type within the system.
+ *
+ * Purpose:
+ * These permissions are used to enforce role-based access control (RBAC) for different user roles (OWNER, SUPERVISOR, EMPLOYEE).
+ * They determine what actions a user can perform on which resources and within what boundaries, ensuring data privacy and security.
+ * Example: 'USER:READ:ASSIGNED' allows a supervisor to read the profiles of employees they supervise, but not other users.
+ */
+
+export const OWNER_PERMISSIONS = [
+  "ORGANIZATION:*:*", // Owners can do anything with all organizations
+  "USER:*:*", // Owners can do anything with all users
+  "RATING:*:*", // Owners can do anything with all ratings
+];
+
+export const SUPERVISOR_PERMISSIONS = [
+  "USER:READ:OWN", // Supervisors can read their own user data
+  "USER:READ:ASSIGNED", // Supervisors can read data of employees they supervise
+  "RATING:READ:OWN", // Supervisors can read their own ratings (as employee or supervisor)
+  "RATING:READ:ASSIGNED", // Supervisors can read ratings of their assigned employees
+  "RATING:CREATE:ASSIGNED", // Supervisors can create ratings for their assigned employees
+  "RATING:UPDATE:ASSIGNED", // Supervisors can update ratings for their assigned employees
+  "RATING:DELETE:ASSIGNED", // Supervisors can delete ratings for their assigned employees
+  "ORGANIZATION:READ:ASSIGNED", // Supervisors can read all data about organizations they are assigned to
+];
+
+export const EMPLOYEE_PERMISSIONS = [
+  "USER:READ:OWN", // Employees can read their own user data
+  "USER:UPDATE:OWN", // Employees can update their own user data
+  "USER:DELETE:OWN", // Employees can delete their own user data (e.g., account deletion)
+  "RATING:READ:OWN", // Employees can read their own ratings
+  "ORGANIZATION:READ:ASSIGNED", // Employees can read all data about organizations they are assigned to
+];

--- a/src/app/api/helpers/checkPermission.ts
+++ b/src/app/api/helpers/checkPermission.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { IJWTPayload } from "./generateToken";
+
+interface PermissionCheckOptions {
+ user: IJWTPayload;
+ organizationId?: string;
+ requiredPermissions: string[];
+}
+
+export default async function checkPermissions({
+ user,
+ organizationId,
+ requiredPermissions,
+}: PermissionCheckOptions): Promise<NextResponse | null> {
+ if (!organizationId || requiredPermissions.length === 0) {
+  return null;
+ }
+
+ // Find the organization membership
+ const orgMembership = user.organizations.find(
+  (org) => org.organizationId === organizationId,
+ );
+
+ if (!orgMembership) {
+  return NextResponse.json(
+   {
+    code: "not-organization-member",
+    message: "You are not a member of this organization",
+   },
+   { status: 403 },
+  );
+ }
+
+ // Check each required permission
+ for (const requiredPermission of requiredPermissions) {
+  const [requiredResource, requiredAction, requiredScope] =
+   requiredPermission.split(":") as [string, string, string];
+
+  // Check if user has this permission in their org permissions
+  const hasPermission = orgMembership.permissions.some((userPermission) => {
+   const [userResource, userAction, userScope] = userPermission.split(":");
+
+   // Check resource match (with wildcard support)
+   if (userResource !== "*" && userResource !== requiredResource) {
+    return false;
+   }
+
+   // Check action match (with wildcard support)
+   if (userAction !== "*" && userAction !== requiredAction) {
+    return false;
+   }
+
+   // Check scope match (with wildcard support)
+   if (userScope !== "*" && userScope !== requiredScope) {
+    return false;
+   }
+
+   return true;
+  });
+
+  if (hasPermission) {
+   return null; // Permission granted
+  }
+ }
+
+ // If we get here, no permissions matched
+ return NextResponse.json(
+  {
+   code: "missing-permissions",
+   message: "You don't have permission to perform this action",
+  },
+  { status: 403 },
+ );
+}


### PR DESCRIPTION
## Add reusable permission check helper with wildcard support

https://kifgo.atlassian.net/browse/ER-27

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Introduced a reusable `checkPermissions` helper function that validates whether a user has the required permissions within a specified organization.  
The function supports wildcard matching in `RESOURCE:ACTION:SCOPE` formatted permissions and returns clear JSON error responses when the user is either not a member of the organization or lacks the required permissions.

## What is fixed / implemented?

- Created `checkPermissions` utility to centralize permission validation logic.
- Supported wildcard matching (`*`) in resource, action, and scope segments.
- Returned appropriate `403 Forbidden` responses for missing membership or permissions.

## Additional Information

_N/A_

## Screenshots (if applicable)

_N/A_

## Checklist

- [ ] I have added or updated relevant tests to cover the changes.
- [X] I have performed a self-review of my code.
- [X] My changes generate no new warnings or errors in development and production builds.
- [ ] I have verified the changes on multiple devices and browsers (if applicable).
- [ ] Environment variables have been updated (if applicable).
- [ ] New packages have been installed and documented (if applicable).
