### PR TITLE
Feature | ER-32 implement generate invite token for organization invitation tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "migrate": "npx prisma db push && npx prisma generate",
-    "create-diff:win": "@powershell -Command \"git diff -- . ':^node_modules' ':^package-lock.json' ':^src/app/fonts' ':^public' | Out-File -FilePath $env:USERPROFILE\\Desktop\\diff.txt; git ls-files --others --exclude-standard ':!node_modules/*' ':!package-lock.json' ':!src/app/fonts/*' ':!public/*' | ForEach-Object { Write-Output ('+++ ' + $_); Get-Content $_ } | Out-File -FilePath $env:USERPROFILE\\Desktop\\diff.txt -Append\"",
+    "create-diff:win": "@powershell -Command \"git diff --cached -- . ':^node_modules' ':^package-lock.json' ':^src/app/fonts' ':^public' | Out-File -FilePath $env:USERPROFILE\\Desktop\\diff.txt; git ls-files --others --exclude-standard ':!node_modules/*' ':!package-lock.json' ':!src/app/fonts/*' ':!public/*' | ForEach-Object { Write-Output ('+++ ' + $_); Get-Content $_ } | Out-File -FilePath $env:USERPROFILE\\Desktop\\diff.txt -Append\"",
     "create-diff:mac": "{ git diff -- . ':(exclude)node_modules' ':(exclude)package-lock.json' ':(exclude)src/app/fonts' ':(exclude)public' && git ls-files --others --exclude-standard ':!node_modules/*' ':!package-lock.json' ':!src/app/fonts/*' ':!public/*' | while read file; do echo \"+++ $file\"; cat \"$file\"; done; } > ~/Desktop/diff.txt"
   },
   "dependencies": {

--- a/src/app/api/organization/[id]/invite/generateInviteToken.ts
+++ b/src/app/api/organization/[id]/invite/generateInviteToken.ts
@@ -1,0 +1,24 @@
+import generateToken from "@/app/api/helpers/generateToken";
+
+export const INVITE_TOKEN_TYPE = "ACCEPT_INVITE";
+
+export interface IJWTInvitePayload extends Record<string, any> {
+  id: string;
+  organizationId: string;
+  type: typeof INVITE_TOKEN_TYPE;
+}
+
+export default function generateInviteToken(payload: {
+  id: string;
+  organizationId: string;
+}) {
+  return generateToken<IJWTInvitePayload>(
+    {
+      ...payload,
+      type: INVITE_TOKEN_TYPE,
+    },
+    {
+      expiresIn: "1h",
+    }
+  );
+}

--- a/src/schemas/user.schema.ts
+++ b/src/schemas/user.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { UserRole } from "@prisma/client";
 import { CreateOrganizationSchema } from "./organization.schama";
 
 const RegisterUserSchema = z
@@ -72,4 +73,17 @@ const LoginUserSchema = z.object({
     .trim(),
 });
 
-export { RegisterUserSchema, LoginUserSchema };
+const InviteUserSchema = z.object({
+  email: z
+    .string({ required_error: "Email is required" })
+    .email({ message: "Invalid email format" })
+    .max(255, { message: "Email cannot exceed 255 characters" })
+    .trim()
+    .toLowerCase(),
+
+  role: z.nativeEnum(UserRole).refine((val) => val !== UserRole.OWNER, {
+    message: "The OWNER role is not allowed for invitations",
+  }),
+});
+
+export { InviteUserSchema, LoginUserSchema, RegisterUserSchema };


### PR DESCRIPTION
## Implement generateInviteToken helper

https://kifgo.atlassian.net/browse/ER-32

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This PR introduces a helper function `generateInviteToken` to create JWT-based invitation tokens for organization invitations. These tokens include the user ID, organization ID, and a token type of `ACCEPT_INVITE`, with an expiry of 1 hour to ensure security.

Additionally, the `create-diff:win` npm script has been updated to use `git diff --cached` so that staged changes are correctly captured when generating a diff file for review.

## What is fixed / implemented?

- Implemented `generateInviteToken.ts` to securely generate invitation tokens
- Updated `create-diff:win` script to include staged changes in diff output

## Additional Information

_N/A_

## Screenshots (if applicable)

_N/A_

## Checklist

- [ ] I have added or updated relevant tests to cover the changes.
- [X] I have performed a self-review of my code.
- [X] My changes generate no new warnings or errors in development and production builds.
- [ ] I have verified the changes on multiple devices and browsers (if applicable).
- [ ] Environment variables have been updated (if applicable).
- [ ] New packages have been installed and documented (if applicable).
