### PR TITLE
Feature | ER-36 Add whoami route to fetch user details by token

### DIFF
--- a/src/app/api/auth/whoami/route.ts
+++ b/src/app/api/auth/whoami/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import privateRoute from "../../helpers/privateRoute";
+import prisma from "@/lib/prisma";
+import handleError from "../../helpers/handleError";
+
+export async function GET(request: NextRequest) {
+  return privateRoute(
+    request,
+    { permissions: [] }, //no specific permissions required beyond authentication
+    async (currentUser) => {
+      try {
+        const user = await prisma.user.findUnique({
+          where: {
+            id: currentUser.id,
+          },
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            createdAt: true,
+            updatedAt: true,
+            OrganizationMembers: {
+              include: {
+                Organization: true,
+                Supervisor: true,
+                Employees: true,
+              },
+            },
+            OwnedOrganizations: true,
+          },
+        });
+
+        if (!user) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: {
+                code: "USER_NOT_FOUND",
+                message: "user not found",
+              },
+            },
+            { status: 404 },
+          );
+        }
+
+        return NextResponse.json(
+          {
+            success: true,
+            data: user,
+          },
+          { status: 200 },
+        );
+      } catch (error) {
+        return handleError(error, "failed to fetch user details");
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Add whoami route to fetch user details by token

https://kifgo.atlassian.net/browse/ER-36

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This pull request introduces a new `/api/auth/whoami` endpoint to retrieve details of the authenticated user. The endpoint uses the `privateRoute` middleware to ensure authentication and fetches user data, including organization memberships, owned organizations, and related supervisor/employee information, using Prisma. Comprehensive error handling is included for cases like user not found or server errors.

## What is fixed / implemented?

- Added GET /api/auth/whoami endpoint to fetch authenticated user details
- Included user fields: id, email, firstName, lastName, createdAt, updatedAt
- Fetched related data: OrganizationMembers, OwnedOrganizations, and nested Organization, Supervisor, and Employees
- Implemented error handling for user not found (404) and server errors
- Utilized `privateRoute` middleware for authentication

## Additional Information

_N/A_

## Screenshots (if applicable)

_N/A_

## Checklist

- [ ] I have added or updated relevant tests to cover the changes.
- [X] I have performed a self-review of my code.
- [X] My changes generate no new warnings or errors in development and production builds.
- [ ] I have verified the changes on multiple devices and browsers (if applicable).
- [ ] Environment variables have been updated (if applicable).
- [ ] New packages have been installed and documented (if applicable).