### PR TITLE
Feature | ER-34 Add email sending functionality with Nodemailer and OAuth2

### DIFF
--- a/src/lib/nodemailer.ts
+++ b/src/lib/nodemailer.ts
@@ -1,0 +1,46 @@
+import { google } from "googleapis";
+import nodemailer from "nodemailer";
+
+const getCredentials = async (): Promise<string | any> => {
+  const oAuth2Client = new google.auth.OAuth2(
+    process.env.OAUTH_CLIENT_ID,
+    process.env.OAUTH_CLIENT_SECRET,
+    process.env.OAUTH_REDIRECT_URI,
+  );
+
+  oAuth2Client.setCredentials({
+    refresh_token: process.env.OAUTH_REFRESH_TOKEN,
+  });
+
+  return await oAuth2Client.getAccessToken();
+};
+
+export async function sendEmail({
+  to,
+  subject,
+  html,
+}: {
+  to: string;
+  subject: string;
+  html: string;
+}) {
+  const credentials = await getCredentials();
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      type: "oauth2",
+      user: "sabesh769@gmail.com",
+      clientId: process.env.OAUTH_CLIENT_ID,
+      clientSecret: process.env.OAUTH_CLIENT_SECRET,
+      refreshToken: process.env.OAUTH_REFRESH_TOKEN,
+      accessToken: credentials,
+    },
+  });
+
+  return await transporter.sendMail({
+    from: "sabesh769@gmail.com",
+    to: to,
+    subject: subject,
+    html,
+  });
+}


### PR DESCRIPTION
## Add email sending functionality with Nodemailer and OAuth2

https://kifgo.atlassian.net/browse/ER-34

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This pull request introduces email sending functionality to the application using Nodemailer with Gmail's OAuth2 authentication. The implementation securely fetches access tokens using Google's OAuth2 client and sends emails with customizable recipients, subjects, and HTML content.

## What is fixed / implemented?

- Added `sendEmail` function in `src/lib/nodemailer.ts` to send emails via Gmail
- Implemented `getCredentials` utility to fetch OAuth2 access tokens
- Configured Nodemailer transporter with OAuth2 authentication
- Added support for environment variables for OAuth2 credentials
- Enabled sending HTML-formatted emails with dynamic recipients and subjects

## Additional Information

_N/A_

## Screenshots (if applicable)

_N/A_

## Checklist

- [ ] I have added or updated relevant tests to cover the changes.
- [X] I have performed a self-review of my code.
- [X] My changes generate no new warnings or errors in development and production builds.
- [ ] I have verified the changes on multiple devices and browsers (if applicable).
- [X] Environment variables have been updated (if applicable).
- [X] New packages have been installed and documented (if applicable).