### PR TITLE
Feature | ER-39 Add protected route and validation for resending organization invites

### DIFF
--- a/src/app/api/organization/[id]/invite/resend/route.tsx
+++ b/src/app/api/organization/[id]/invite/resend/route.tsx
@@ -1,0 +1,27 @@
+import privateRoute from "@/app/api/helpers/privateRoute";
+import { NextRequest, NextResponse } from "next/server";
+import { ResendInviteSchema } from "@/schemas/user.schema";
+import handleError from "@/app/api/helpers/handleError";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: organizationId } = await params;
+  const body = await request.json();
+
+  return privateRoute(
+    request,
+    {
+      organizationId,
+      permissions: ["ORGANIZATION::", "ORGANIZATION:INVITE:*"],
+    },
+    async (inviter) => {
+      try {
+        const { id: invitedUserId } = ResendInviteSchema.parse(body);
+      } catch (error) {
+        return handleError(error, "Failed to resend invitation");
+      }
+    },
+  );
+}

--- a/src/schemas/user.schema.ts
+++ b/src/schemas/user.schema.ts
@@ -86,4 +86,11 @@ const InviteUserSchema = z.object({
   }),
 });
 
-export { InviteUserSchema, LoginUserSchema, RegisterUserSchema };
+const ResendInviteSchema = z.object({
+  id: z
+    .string({ required_error: "id is required" })
+    .max(255, { message: "Id cannot exceed 255 characters" })
+    .trim(),
+});
+
+export { InviteUserSchema, LoginUserSchema, RegisterUserSchema ,ResendInviteSchema };


### PR DESCRIPTION
## Add protected route and validation for resending organization invites

https://kifgo.atlassian.net/browse/ER-39

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Added a protected POST endpoint to resend organization invites. This includes setting up route protection using the `privateRoute` helper and validating the request body with a Zod schema (`ResendInviteSchema`). Only users with the correct permissions can trigger the resend logic.

## What is fixed / implemented?

- Implemented `ResendInviteSchema` to validate the invite user ID in the request body.
- Secured the resend invite route with `privateRoute`, enforcing `ORGANIZATION::*` and `ORGANIZATION:INVITE:*` permissions.
- Ensured only organization owners or authorized users can resend invitations.

## Additional Information

_N/A_

## Screenshots (if applicable)

_N/A_

## Checklist

- [ ] I have added or updated relevant tests to cover the changes.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors in development and production builds.
- [ ] I have verified the changes on multiple devices and browsers (if applicable).
- [ ] Environment variables have been updated (if applicable).
- [ ] New packages have been installed and documented (if applicable).
