### PR TITLE
Feature | ER-41 implement prisma queries for invite organization checks

### DIFF
--- a/src/app/api/organization/[id]/invite/resend/route.tsx
+++ b/src/app/api/organization/[id]/invite/resend/route.tsx
@@ -1,0 +1,27 @@
+import privateRoute from "@/app/api/helpers/privateRoute";
+import { NextRequest, NextResponse } from "next/server";
+import { ResendInviteSchema } from "@/schemas/user.schema";
+import handleError from "@/app/api/helpers/handleError";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: organizationId } = await params;
+  const body = await request.json();
+
+  return privateRoute(
+    request,
+    {
+      organizationId,
+      permissions: ["ORGANIZATION::", "ORGANIZATION:INVITE:*"],
+    },
+    async (inviter) => {
+      try {
+        const { id: invitedUserId } = ResendInviteSchema.parse(body);
+      } catch (error) {
+        return handleError(error, "Failed to resend invitation");
+      }
+    },
+  );
+}

--- a/src/app/api/organization/[id]/invite/resend/route.tsx
+++ b/src/app/api/organization/[id]/invite/resend/route.tsx
@@ -2,6 +2,8 @@ import privateRoute from "@/app/api/helpers/privateRoute";
 import { NextRequest, NextResponse } from "next/server";
 import { ResendInviteSchema } from "@/schemas/user.schema";
 import handleError from "@/app/api/helpers/handleError";
+import { UserStatus } from "@prisma/client";
+import prisma from "@/lib/prisma";
 
 export async function POST(
   request: NextRequest,
@@ -19,6 +21,58 @@ export async function POST(
     async (inviter) => {
       try {
         const { id: invitedUserId } = ResendInviteSchema.parse(body);
+
+        const [organization, invitedUser] = await Promise.all([
+          prisma.organization.findUnique({
+            where: {
+              id: organizationId,
+            },
+            select: {
+              id: true,
+              name: true,
+              ownerId: true,
+            },
+          }),
+          prisma.user.findUnique({
+            where: {
+              id: invitedUserId,
+            },
+            include: {
+              OrganizationMembers: {
+                where: {
+                  organizationId,
+                  status: UserStatus.INVITED,
+                },
+              },
+            },
+          }),
+        ]);
+
+        if (!invitedUser || invitedUser.OrganizationMembers.length === 0) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: {
+                code: "INVITATION_NOT_FOUND",
+                message: "invitation not found",
+              },
+            },
+            { status: 404 },
+          );
+        }
+
+        if (!organization || organization.ownerId !== inviter.id) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: {
+                code: "ORGANIZATION_NOT_FOUND",
+                message: "Organization is not found or inactive.",
+              },
+            },
+            { status: 404 },
+          );
+        }
       } catch (error) {
         return handleError(error, "Failed to resend invitation");
       }

--- a/src/schemas/user.schema.ts
+++ b/src/schemas/user.schema.ts
@@ -86,4 +86,11 @@ const InviteUserSchema = z.object({
   }),
 });
 
-export { InviteUserSchema, LoginUserSchema, RegisterUserSchema };
+const ResendInviteSchema = z.object({
+  id: z
+    .string({ required_error: "id is required" })
+    .max(255, { message: "Id cannot exceed 255 characters" })
+    .trim(),
+});
+
+export { InviteUserSchema, LoginUserSchema, RegisterUserSchema ,ResendInviteSchema };


### PR DESCRIPTION
## Validate organization ownership and invitation status before accepting user invite

https://kifgo.atlassian.net/browse/ER-41

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This PR adds validation logic to ensure that only the organization owner can accept invitations and that the invited user exists with a pending invitation. It performs a parallel lookup of both the organization and the user, verifies the inviter's ownership, and checks the invited user's membership status.

## What is fixed / implemented?

- Fetches the organization and invited user in parallel
- Confirms that the invited user has a pending invite to the specified organization
- Validates that the inviter is the owner of the organization
- Returns appropriate 404 errors when validation fails

## Additional Information

_N/A_

## Screenshots (if applicable)

_N/A_

## Checklist

- [ ] I have added or updated relevant tests to cover the changes.
- [X] I have performed a self-review of my code.
- [X] My changes generate no new warnings or errors in development and production builds.
- [ ] I have verified the changes on multiple devices and browsers (if applicable).
- [ ] Environment variables have been updated (if applicable).
- [ ] New packages have been installed and documented (if applicable).
