### PR TITLE
Feature | ER-65 Validate criteria IDs belong to organization in rating endpoint

### DIFF
--- a/src/app/api/organization/[id]/rating/route.ts
+++ b/src/app/api/organization/[id]/rating/route.ts
@@ -48,6 +48,36 @@ export async function POST(
             { status: 403 },
           );
         }
+
+       //Get all criteria IDs from the payload
+        const criteriaIds = criteriaScores.map((cs) => cs.criteriaId);
+        // Find all matching criteria in the organization
+        const criteria = await prisma.criteria.findMany({
+          where: {
+            id: { in: criteriaIds },
+            orgId: organizationId,
+          },
+          select: { id: true },
+        });
+        // Validate all IDs exist
+        if (criteria.length !== criteriaScores.length) {
+          const validIds = new Set(criteria.map((c) => c.id));
+          const missingIds = criteriaScores
+            .filter((cs) => !validIds.has(cs.criteriaId))
+            .map((cs) => cs.criteriaId);
+          return NextResponse.json(
+            {
+              success: false,
+              error: {
+                code: "INVALID_CRITERIA",
+                message: `The following criteria do not belong to this organization: ${missingIds.join(", ")}`,
+              },
+            },
+            { status: 400 },
+          );
+        }
+
+        return NextResponse.json({ success: true });
       } catch (error) {
         return handleError(error, "Failed to create rating");
       }

--- a/src/app/api/organization/[id]/rating/route.ts
+++ b/src/app/api/organization/[id]/rating/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import privateRoute from "@/app/api/helpers/privateRoute";
+import handleError from "@/app/api/helpers/handleError";
+import { createRatingSchema } from "@/schemas/rating.schema";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: organizationId } = await params;
+  const body = await request.json();
+
+  return privateRoute(
+    request,
+    {
+      organizationId,
+      permissions: ["RATING:*:*", "RATING:CREATE:*", "RATING:CREATE:ASSIGNED"],
+    },
+    async (user) => {
+      try {
+        //validation
+        const parsed = createRatingSchema.parse(body);
+
+        const { employeeId, periodStart, periodEnd, feedback, criteriaScores } =
+          parsed;
+
+        // Find supervisor's membership in this organization
+        const supervisorMembership = await prisma.organizationMember.findFirst({
+          where: {
+            userId: employeeId,
+            supervisorId: user.id,
+          },
+          include: {
+            Organization: true,
+          },
+        });
+
+        if (!supervisorMembership) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: {
+                code: "NOT_SUPERVISOR",
+                message: "You are not the supervisor of this employee",
+              },
+            },
+            { status: 403 },
+          );
+        }
+      } catch (error) {
+        return handleError(error, "Failed to create rating");
+      }
+    },
+  );
+}

--- a/src/schemas/rating.schema.ts
+++ b/src/schemas/rating.schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+export const createRatingSchema = z.object({
+  employeeId: z.string().min(1, { message: "Employee ID is required" }),
+  periodStart: z.string().refine((date) => !isNaN(Date.parse(date)), {
+    message: "Invalid start date",
+  }),
+  periodEnd: z.string().refine((date) => !isNaN(Date.parse(date)), {
+    message: "Invalid end date",
+  }),
+  feedback: z.string().optional(),
+  criteriaScores: z
+    .array(
+      z.object({
+        criteriaId: z.string().min(1, { message: "Criteria ID is required" }),
+        score: z
+          .number()
+          .int()
+          .min(0, { message: "Score must be a non-negative integer" }),
+      }),
+    )
+    .min(1, { message: "At least one criteria score is required" }),
+});


### PR DESCRIPTION
## Validate criteria IDs belong to organization in rating endpoint

https://kifgo.atlassian.net/browse/ER-65

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Added validation in the rating API endpoint to ensure that all criteria IDs provided in the payload belong to the specified organization. If any criteria IDs are invalid or missing, the endpoint returns a 400 error with a detailed message listing those IDs. This prevents assigning ratings to criteria outside the organization's scope.

## What is fixed / implemented?

- Extract criteria IDs from the payload
- Fetch matching criteria for the organization from the database
- Validate that all criteria IDs exist and belong to the organization
- Return a descriptive error if validation fails

## Additional Information

_N/A_

## Screenshots (if applicable)

_N/A_

## Checklist

- [ ] I have added or updated relevant tests to cover the changes.
- [X] I have performed a self-review of my code.
- [X] My changes generate no new warnings or errors in development and production builds.
- [ ] I have verified the changes on multiple devices and browsers (if applicable).
- [ ] Environment variables have been updated (if applicable).
- [ ] New packages have been installed and documented (if applicable).
