### PR TITLE
Feature | ER-84 Implement useRegister Hook for User Registration

### DIFF
--- a/src/app/api-client/register/register.ts
+++ b/src/app/api-client/register/register.ts
@@ -1,0 +1,24 @@
+import { useApi } from "@/providers/ApiProvider";
+import { User } from "@prisma/client";
+import { useCreateMutation } from "../apiFactory";
+import { RegisterInput } from "@/app/api/auth/types";
+export const useRegister = ({
+  invalidateQueryKey,
+}: {
+  invalidateQueryKey?: unknown[];
+}) => {
+  const { jsonApiClient } = useApi();
+  return useCreateMutation<
+    Record<string, any>, // optimistic update data (none here)
+    RegisterInput, // request body
+    { data: { user: User; token: string } }, // server response type (on success)
+    { data: { user: User; token: string } } // error response shape (if structured)
+  >({
+    apiClient: jsonApiClient,
+    method: "post",
+    url: "/auth/register",
+    errorMessage: "Failed to register user.",
+    invalidateQueryKey,
+    mutationOptions: {},
+  });
+};

--- a/src/app/api/auth/types.ts
+++ b/src/app/api/auth/types.ts
@@ -1,4 +1,4 @@
-import { LoginUserSchema } from "@/schemas/user.schema";
+import { LoginUserSchema, RegisterUserSchema } from "@/schemas/user.schema";
 import { Prisma, User } from "@prisma/client";
 import { z } from "zod";
 
@@ -9,6 +9,8 @@ export type LoginInput = z.infer<typeof LoginUserSchema>;
 export type UserWithOrgMembers = Prisma.UserGetPayload<{
   include: { OrganizationMembers: true };
 }>;
+
+export type RegisterInput = z.infer<typeof RegisterUserSchema>;
 
 export type UserWithRelations = Prisma.UserGetPayload<{
   select: {


### PR DESCRIPTION
## Implement useRegister Hook for User Registration

https://kifgo.atlassian.net/browse/ER-84

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Added a reusable `useRegister` React hook located at `src/app/api-client/register/register.ts`. This hook integrates with the `/auth/register` endpoint using the centralized `useCreateMutation` pattern and shared `jsonApiClient`. It streamlines the registration process and aligns with the application's existing API interaction architecture.

## What is fixed / implemented?

- Implements `useRegister` hook using `useCreateMutation` for handling API calls.
- Accepts `RegisterInput` as request body schema and uses strict response typing via Prisma’s `User` type.
- Handles error responses consistently with other API interactions.
- Displays "Failed to register user." toast on error.
- Accepts optional `invalidateQueryKey` for cache invalidation support.
- Designed to integrate with `react-hot-toast` for feedback and `useApi` from `ApiProvider`.

## Additional Information

- The optimistic update type is `Record<string, any>`, unused but required for typing consistency.
- No breaking changes introduced.
- Hook is ready to be consumed by components handling user registration flows.

## Screenshots (if applicable)

_N/A_

## Checklist

- [ ] I have added or updated relevant tests to cover the changes.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors in development and production builds.
- [ ] I have verified the changes on multiple devices and browsers (if applicable).
- [ ] Environment variables have been updated (if applicable).
- [ ] New packages have been installed and documented (if applicable).
